### PR TITLE
fix: enable debug mode for database migrations to improve error visibility

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -28,7 +28,7 @@ func ConnectDB() *gorm.DB {
 
 	db, err := gorm.Open(mysql.Open(dsn), &gorm.Config{})
 
-	err = db.AutoMigrate(&models.User{}, &models.Experience{}, &models.Project{}, &models.Education{})
+	err = db.Debug().AutoMigrate(&models.User{}, &models.Experience{}, &models.Project{}, &models.Education{})
 	if err != nil {
 		log.Fatalf("Error running database migrations: %v", err)
 		return nil


### PR DESCRIPTION
This pull request makes a minor update to the `ConnectDB` function in `config/config.go` to enable debugging for database migrations.

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L31-R31): Modified the `AutoMigrate` call to include the `Debug()` method, which enables detailed logging during the database migration process.