### PR TITLE
fix: refactor environment variable loading to ensure it only occurs in debug mode

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -13,9 +13,11 @@ import (
 var DB *gorm.DB
 
 func ConnectDB() *gorm.DB {
-	if err := godotenv.Load(); err != nil {
-		log.Printf("Warning: Error loading .env file: %v", err)
-		// Don't return here in production, env vars might be set elsewhere
+	if os.Getenv("GIN_MODE") == "debug" {
+		if err := godotenv.Load(); err != nil {
+			log.Printf("Warning: Error loading .env file: %v", err)
+			// Don't return here in production, env vars might be set elsewhere
+		}
 	}
 
 	dbUser := os.Getenv("DB_USER")


### PR DESCRIPTION
This pull request introduces a conditional check to load environment variables from a `.env` file only when the application is running in debug mode. This ensures that `.env` loading is skipped in production environments.

Key change:

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17R16-R21): Added a conditional check to load the `.env` file only if the `GIN_MODE` environment variable is set to `debug`. This prevents unnecessary `.env` file loading in production environments.