### PR TITLE
fix: correct database connection logging format to include password

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -27,7 +27,7 @@ func ConnectDB() *gorm.DB {
 	dbName := os.Getenv("DB_NAME")
 
 	// Add debug logging to check if env vars are set
-	log.Printf("Connecting to database: %s@%s:%s/%s", dbUser, dbHost, dbPort, dbName)
+	log.Printf("Connecting to database: %s:%s@%s:%s/%s", dbUser, dbPassword, dbHost, dbPort, dbName)
 
 	dsn := dbUser + ":" + dbPassword + "@tcp(" + dbHost + ":" + dbPort + ")/" + dbName + "?charset=utf8mb4&parseTime=True&loc=Local"
 


### PR DESCRIPTION
This pull request includes a minor update to the database connection logging in the `ConnectDB` function within `config/config.go`. The change ensures that the database password (`dbPassword`) is included in the log message for debugging purposes.

* [`config/config.go`](diffhunk://#diff-fe44f09c4d5977b5f5eaea29170b6a0748819c9d02271746a20d81a5f3efca17L30-R30): Updated the log message in the `ConnectDB` function to include the `dbPassword` variable for better visibility during debugging.